### PR TITLE
Fixed token as per new requirements.

### DIFF
--- a/reminder.go
+++ b/reminder.go
@@ -116,7 +116,7 @@ func main() {
 
 	log.Debug("Log set up")
 
-	dg, err := discordgo.New(*TOKEN)
+	dg, err := discordgo.New("Bot " + *TOKEN)
 	if err != nil {
 		flag.Usage()
 		log.WithFields(log.Fields{


### PR DESCRIPTION
Something like 6 months ago (September 2016), discord required authentication tokens to have "Bot " appended to the front of the string.